### PR TITLE
카카오 로그인 javascript sdk로 수정

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 REACT_APP_BASE_URL=https://api.togethery.store
+REACT_APP_KAKAO_JS_KEY=46abf520fd564d48e57f05672c840981

--- a/.idea/tcc.iml
+++ b/.idea/tcc.iml
@@ -8,5 +8,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="kakao" level="application" />
   </component>
 </module>

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 
     <base href="/" />
     <title>React App</title>
+    <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js" integrity="sha384-DKYJZ8NLiK8MN4/C5P2dtSmLQ4KwPaoqAfyA/DfmEc1VDxu4yyC7wy6K1Hs90nka" crossorigin="anonymous"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,23 @@ import { Outlet, useLocation } from "react-router-dom";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
 import { Layout, MainContent } from "./components/layout/Layout";
-import { Suspense } from "react";
+import {Suspense, useEffect} from "react";
 
+declare global {
+  interface Window {
+    Kakao: any;
+  }
+}
 const App = () => {
   const location = useLocation();
   const hidePage = ["/", "/signup"].includes(location.pathname);
+
+  useEffect(() => {
+    if (window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.REACT_APP_KAKAO_JS_KEY);
+    }
+  }, []);
+
   return (
     <>
       <Suspense fallback={<div>로딩 중...</div>}>

--- a/src/pages/login/components/KakaoLogin.tsx
+++ b/src/pages/login/components/KakaoLogin.tsx
@@ -5,7 +5,7 @@ import { KakaoBtn } from "./Login.style";
 const KakaoLogin = () => {
   const KakaoLogin = () => {
       window.Kakao.Auth.authorize({
-          redirectUri: 'https://accounts.togethery.store/login/oauth2/code/kakao',
+          redirectUri: 'https://accounts.togethery.store/auth/callback',
       });
   }
   return (

--- a/src/pages/login/components/KakaoLogin.tsx
+++ b/src/pages/login/components/KakaoLogin.tsx
@@ -4,7 +4,9 @@ import { KakaoBtn } from "./Login.style";
 
 const KakaoLogin = () => {
   const KakaoLogin = () => {
-    window.Kakao.Auth.login();
+      window.Kakao.Auth.authorize({
+          redirectUri: 'https://accounts.togethery.store/login/oauth2/code/kakao',
+      });
   }
   return (
     <>

--- a/src/pages/login/components/KakaoLogin.tsx
+++ b/src/pages/login/components/KakaoLogin.tsx
@@ -3,50 +3,12 @@ import kakao from "../../../images/login/kakao.svg";
 import { KakaoBtn } from "./Login.style";
 
 const KakaoLogin = () => {
-  // const kakaoLoginURL = ``;
-
-  //const kakao_login = () => {
-  //   localStorage.clear();
-  //   window.open(kakaoLoginURL, "_self");
-  // };
-  // const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=70f9602918e39f149728c1c18b7fc545&redirect_uri=http://158.247.198.100:32001/login/oauth2/code/kakao&response_type=code`;
-  const KAKAO_AUTH_URL = `https://accounts.togethery.store/oauth2/authorization/kakao`;
-
-  const handleLogin = () => {
-    window.location.href = KAKAO_AUTH_URL;
-  };
-
-  // const instanceUtil = axios.create({
-  //     baseURL:"http://localhost:8080",
-  //     headers: {
-  //         "Content-type": "application/json",
-  //     },
-  // });
-  // const signUp = async (code:string) => {
-  //     try {
-  //         const response = await instanceUtil.get(`/user/signin/?code=${code}`);
-  //
-  //         return response.data;
-  //     } catch (error) {
-  //         console.error(error);
-  //         return error;
-  //     }
-  // };
-
-  // const sign = async () => {
-  //     try {
-  //         const response = await instanceUtil.get(`/oauth2/authorization/kakao`);
-  //
-  //         return response.data;
-  //     } catch (error) {
-  //         console.error(error);
-  //         return error;
-  //     }
-  // };
-
+  const KakaoLogin = () => {
+    window.Kakao.Auth.login();
+  }
   return (
     <>
-      <KakaoBtn onClick={handleLogin}>
+      <KakaoBtn onClick={KakaoLogin}>
         <img src={kakao} alt="kakao login" />
         <span>카카오계정으로 시작하기</span>
       </KakaoBtn>


### PR DESCRIPTION
## ⚠️ 관련 이슈
#64 

## 문제 상황
기존 카카오톡 로그인 기능은 앱에서 실행했을 때 사파리로만 연결
카카오톡 어플이 열리는게 아니다보니 직접 아이디, 비밀번호를 매번 입력해야 로그인이 가능했음
현재는 REST API 방식으로 로그인하고 있었는데, 카카오 디벨로퍼 공식문서를 참조해보니 우리 상황처럼 네이티브앱에서 웹뷰를 띄워서 로그인하는 경우 JavaScript SDK를 사용하라고 안내하고 있어서 해당 방법으로 수정



## 상세 기록
https://www.notion.so/18e22bdd8d8c80bab9afe912d03a7476?pvs=4

## 🚧 작업 내용


## ✅ PR 유형

- [x] 새로운 기능 추가

## 참조 문헌
https://developers.kakao.com/docs/latest/ko/javascript/getting-started
https://developers.kakao.com/docs/latest/ko/javascript/hybrid
